### PR TITLE
Handle Discord errors in background tasks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -542,9 +542,14 @@ async def check_ingame():
                 if champion_image_url:
                     embed.set_thumbnail(url=champion_image_url)
 
-                msg = await channel.send(embed=embed)
-                players_in_game.add(puuid)
-                players_in_game_messages[puuid] = msg
+                try:
+                    msg = await channel.send(embed=embed)
+                except discord.DiscordException as e:
+                    logging.error(f"[check_ingame] Failed to send in-game embed: {e}")
+                    msg = None
+                if msg:
+                    players_in_game.add(puuid)
+                    players_in_game_messages[puuid] = msg
 
             elif champion_id is None and puuid in players_in_game:
                 players_in_game.discard(puuid)
@@ -642,8 +647,8 @@ async def check_for_game_completion():
             if in_game_msg:
                 try:
                     await in_game_msg.delete()
-                except Exception:
-                    pass
+                except discord.DiscordException as e:
+                    logging.error(f"[check_for_game_completion] Failed to delete in-game message: {e}")
 
             alert_channel = client.get_channel(int(alert_channel_id))
             if alert_channel:
@@ -684,7 +689,10 @@ async def send_match_result_embed(channel, username, result, kills, deaths, assi
     embed.add_field(name="Damage", value=f"{damage}", inline=True)
     embed.add_field(name=lp_text, value=f"{'+' if lp_change > 0 else ''}{lp_change} LP", inline=True)
     embed.set_thumbnail(url=champion_image)
-    await channel.send(embed=embed)
+    try:
+        await channel.send(embed=embed)
+    except discord.DiscordException as e:
+        logging.error(f"[send_match_result_embed] Failed to send match result: {e}")
 
 @client.event
 async def on_ready():

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -204,7 +204,10 @@ async def update_leaderboard_message(channel_id: int, bot: discord.Client, guild
             return
 
     # 7) Sinon, envoie un nouveau message
-    await channel.send(table)
+    try:
+        await channel.send(table)
+    except discord.DiscordException as e:
+        logging.error(f"[update_leaderboard_message] Failed to send leaderboard: {e}")
 
 
 def setup_tree(tree_obj: app_commands.CommandTree):


### PR DESCRIPTION
## Summary
- handle failures when sending alert embeds from `check_ingame`
- handle deletion errors in `check_for_game_completion`
- log send failures in `send_match_result_embed`
- ensure leaderboard messages log Discord failures

## Testing
- `python -m py_compile bot.py leaderboard.py log.py`

------
https://chatgpt.com/codex/tasks/task_e_6840b9f3a38c8324922373b8ef562639