### PR TITLE
Fix player insertion and active game lookup

### DIFF
--- a/fonction_bdd.py
+++ b/fonction_bdd.py
@@ -10,11 +10,11 @@ def get_connection():
     return conn
 
 
-def insert_player(summoner_id: str,
+def insert_player(username: str,
                   puuid: str,
-                  username: str,
-                  tier: str,
+                  summoner_id: str,
                   rank: str,
+                  tier: str,
                   lp: int):
     """
     Insert or update des données globales du joueur.
@@ -24,19 +24,19 @@ def insert_player(summoner_id: str,
     # Insert initial si absent
     c.execute("""
               INSERT OR IGNORE INTO player
-              (puuid, username, summoner_id, tier, rank, lp, lp_24h, lp_7d, created_at, updated_at)
+              (username, puuid, summoner_id, rank, tier, lp, lp_24h, lp_7d, created_at, updated_at)
               VALUES (?, ?, ?, ?, ?, ?, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-              """, (puuid, username, summoner_id, tier, rank, lp))
+              """, (username, puuid, summoner_id, rank, tier, lp))
     c.execute("""
               UPDATE player
               SET username = ?,
                   summoner_id = ?,
-                  tier = ?,
                   rank = ?,
+                  tier = ?,
                   lp = ?,
                   updated_at = CURRENT_TIMESTAMP
               WHERE puuid = ?
-              """, (username, summoner_id, tier, rank, lp, puuid))
+              """, (username, summoner_id, rank, tier, lp, puuid))
     conn.commit()
     conn.close()
 

--- a/tests/test_calculate_lp_change.py
+++ b/tests/test_calculate_lp_change.py
@@ -31,3 +31,17 @@ def test_lp_rank_changes(bot_module):
 
 def test_lp_invalid_values(bot_module):
     assert bot_module.calculate_lp_change("V", "GOLD", 50, "IV", "GOLD", 60) == 0
+
+
+def test_lp_to_master(bot_module):
+    # From DIAMOND I 80 LP to MASTER 0 LP should require 20 LP
+    assert bot_module.calculate_lp_change(
+        "I", "DIAMOND", 80, "", "MASTER", 0
+    ) == 20
+
+
+def test_lp_master_to_grandmaster(bot_module):
+    # From MASTER 40 LP to GRANDMASTER 0 LP should require 160 LP
+    assert bot_module.calculate_lp_change(
+        "", "MASTER", 40, "", "GRANDMASTER", 0
+    ) == 160


### PR DESCRIPTION
## Summary
- correct player insertion order to store username and PUUID properly
- adjust `register` to match new `insert_player` signature
- use summoner IDs when checking active games

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68432bd758008324b642e515e0dcaeab