### PR TITLE
Fix missing channel error in leaderboard update

### DIFF
--- a/leaderboard.py
+++ b/leaderboard.py
@@ -193,7 +193,19 @@ async def update_leaderboard_message(channel_id: int, bot: discord.Client, guild
 
     # 6) Recherche un ancien message à éditer
     guild_obj = bot.get_guild(guild_id)
-    channel   = guild_obj.get_channel(channel_id)
+    if guild_obj is None:
+        logging.error(
+            f"[update_leaderboard_message] Guild with id {guild_id} not found"
+        )
+        return
+
+    channel = guild_obj.get_channel(channel_id)
+    if channel is None:
+        logging.error(
+            f"[update_leaderboard_message] Channel with id {channel_id} not found"
+        )
+        return
+
     async for msg in channel.history(limit=50):
         if (
                 msg.author == guild_obj.me


### PR DESCRIPTION
## Summary
- handle cases where the guild or channel cannot be found before accessing history

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496285c2248324b829a4c3a7db71d7