### PR TITLE
Prevent check_ingame log spam

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ They can be exported in your shell or placed in a `.env` file.
    python bot.py
    ```
 
+When the bot loses permission to send alerts in a configured channel, it
+automatically disables alerts for that player in that server to avoid cluttering
+the logs.
+
 ## Running Tests
 
 With the virtual environment active and dependencies installed, run:

--- a/bot.py
+++ b/bot.py
@@ -644,6 +644,12 @@ async def check_ingame():
 
                 try:
                     msg = await channel.send(embed=embed)
+                except discord.Forbidden:
+                    logging.warning(
+                        f"[check_ingame] Missing access to channel {channel_id}. Disabling alerts."
+                    )
+                    update_player_guild(puuid, guild_id, channel_id=0)
+                    msg = None
                 except discord.DiscordException as e:
                     logging.error(f"[check_ingame] Failed to send in-game embed: {e}")
                     msg = None


### PR DESCRIPTION
## Summary
- disable alerts for a player when `check_ingame` hits a missing access error
- document the automatic disable behaviour in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d423320348324acdd5e6b7ccc51c5