### PR TITLE
Add region aliases and default to EUW

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ They can be exported in your shell or placed in a `.env` file.
    python bot.py
    ```
 
+When registering a player with `/register`, you can now provide the platform
+region (e.g. `euw`, `na`). The bot will use this region for all Riot API
+requests for that player.
+
 For the music reaction feature to work, place your MP3 files in the
 `music/` directory and install `ffmpeg` on your system. Reacting to either
 the victory/defeat or in‑game status embeds with a supported emoji will play

--- a/create_db.py
+++ b/create_db.py
@@ -21,6 +21,7 @@ def create_db():
             username TEXT NOT NULL,
             puuid TEXT PRIMARY KEY,
             summoner_id TEXT NOT NULL,
+            region TEXT NOT NULL DEFAULT 'euw1',
             rank TEXT,
             tier TEXT,
             lp INTEGER,

--- a/fonction_bdd.py
+++ b/fonction_bdd.py
@@ -13,6 +13,7 @@ def get_connection():
 def insert_player(summoner_id: str,
                   puuid: str,
                   username: str,
+                  region: str,
                   tier: str,
                   rank: str,
                   lp: int):
@@ -24,19 +25,20 @@ def insert_player(summoner_id: str,
     # Insert initial si absent
     c.execute("""
               INSERT OR IGNORE INTO player
-              (puuid, username, summoner_id, tier, rank, lp, lp_24h, lp_7d, created_at, updated_at)
-              VALUES (?, ?, ?, ?, ?, ?, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-              """, (puuid, username, summoner_id, tier, rank, lp))
+              (puuid, username, summoner_id, region, tier, rank, lp, lp_24h, lp_7d, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+              """, (puuid, username, summoner_id, region, tier, rank, lp))
     c.execute("""
               UPDATE player
               SET username = ?,
                   summoner_id = ?,
+                  region = ?,
                   tier = ?,
                   rank = ?,
                   lp = ?,
                   updated_at = CURRENT_TIMESTAMP
               WHERE puuid = ?
-              """, (username, summoner_id, tier, rank, lp, puuid))
+              """, (username, summoner_id, region, tier, rank, lp, puuid))
     conn.commit()
     conn.close()
 
@@ -159,7 +161,7 @@ def get_player(puuid: str, guild_id: int):
               SELECT
                   p.summoner_id, p.puuid, p.username,
                   pg.guild_id, pg.channel_id, pg.last_match_id,
-                  p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d
+                  p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d, p.region
               FROM player p
                        JOIN player_guild pg ON p.puuid = pg.player_puuid
               WHERE p.puuid = ? AND pg.guild_id = ?
@@ -176,7 +178,7 @@ def get_all_players():
               SELECT
                   p.summoner_id, p.puuid, p.username,
                   pg.guild_id, pg.channel_id, pg.last_match_id,
-                  p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d
+                  p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d, p.region
               FROM player p
                        JOIN player_guild pg ON p.puuid = pg.player_puuid
               """)
@@ -193,7 +195,7 @@ def get_player_by_username(username: str, guild_id: int = None):
                   SELECT
                       p.summoner_id, p.puuid, p.username,
                       pg.guild_id, pg.channel_id, pg.last_match_id,
-                      p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d
+                      p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d, p.region
                   FROM player p
                            JOIN player_guild pg ON p.puuid = pg.player_puuid
                   WHERE p.username = ? AND pg.guild_id = ?


### PR DESCRIPTION
## Summary
- accept shorthand region names like `euw` or `na` and map them to full Riot platform codes
- default `/register` region parameter to `euw`
- store normalized region codes
- document shorter region names in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685eab14ec108324ad7e89d434b798ab