### PR TITLE
Auto-update registration message

### DIFF
--- a/register_stats.py
+++ b/register_stats.py
@@ -1,0 +1,51 @@
+import logging
+import discord
+
+from fonction_bdd import count_players
+
+ADMIN_CHANNEL_ID = 1388885265426415726
+
+async def update_register_message(channel_id: int, bot: discord.Client):
+    """Send or edit a table with registration and in-game stats."""
+    registered_total = count_players()
+    ingame_total = len(getattr(bot, "players_in_game", []))
+
+    header1 = "Register"
+    sep1 = "-" * len(header1)
+    header2 = "Players in game"
+    sep2 = "-" * len(header2)
+
+    lines = [
+        header1,
+        sep1,
+        str(registered_total),
+        "",
+        header2,
+        sep2,
+        str(ingame_total),
+    ]
+    table = "```" + "\n".join(lines) + "```"
+
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        logging.error(
+            f"[update_register_message] Channel with id {channel_id} not found"
+        )
+        return
+
+    async for msg in channel.history(limit=50):
+        if (
+            msg.author == bot.user
+            and msg.content.startswith("```")
+            and header1 in msg.content
+        ):
+            await msg.edit(content=table)
+            return
+
+    try:
+        await channel.send(table)
+    except discord.DiscordException as e:
+        logging.error(f"[update_register_message] Failed to send register stats: {e}")
+
+
+

--- a/tests/test_check_game_completion.py
+++ b/tests/test_check_game_completion.py
@@ -28,6 +28,7 @@ def test_check_for_game_completion_handles_missing_row(bot_module):
     with (
         patch.object(bot_module, 'async_get_all_players', async_get_all_players),
         patch('asyncio.sleep', sleep_mock),
+        patch.object(bot_module.register_stats, 'update_register_message', new=AsyncMock()),
     ):
         with pytest.raises(asyncio.CancelledError):
             asyncio.run(bot_module.check_for_game_completion())

--- a/tests/test_update_register_message.py
+++ b/tests/test_update_register_message.py
@@ -1,0 +1,66 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch, AsyncMock
+import asyncio
+import pytest
+
+@pytest.fixture(scope="module")
+def register_module():
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    if 'register_stats' in sys.modules:
+        del sys.modules['register_stats']
+    module = importlib.import_module('register_stats')
+    return module
+
+
+def test_update_register_message_missing_channel(register_module):
+    bot = MagicMock()
+    bot.get_channel.return_value = None
+
+    with (
+        patch.object(register_module.logging, 'error') as log_error,
+        patch.object(register_module, 'count_players', return_value=5)
+    ):
+        asyncio.run(register_module.update_register_message(123, bot))
+        log_error.assert_called_once_with(
+            '[update_register_message] Channel with id 123 not found'
+        )
+
+
+def test_update_register_message_updates_existing(register_module):
+    bot = MagicMock()
+    bot.user = object()
+    bot.players_in_game = {('p', 1)}
+
+    msg = MagicMock()
+    msg.author = bot.user
+    msg.content = '```Register\n--------\n1```'
+    msg.edit = AsyncMock()
+
+    async def history(limit=50):
+        yield msg
+
+    channel = MagicMock()
+    channel.history.side_effect = history
+    bot.get_channel.return_value = channel
+
+    expected_lines = [
+        'Register',
+        '--------',
+        '5',
+        '',
+        'Players in game',
+        '---------------',
+        '1',
+    ]
+    expected_table = '```' + '\n'.join(expected_lines) + '```'
+
+    with (
+        patch.object(register_module, 'count_players', return_value=5),
+    ):
+        asyncio.run(register_module.update_register_message(1, bot))
+
+    msg.edit.assert_awaited_once_with(content=expected_table)
+


### PR DESCRIPTION
## Summary
- remove `/registerstats` command and keep helper
- refresh register stats after registration, unregistration, or in-game updates
- patch tests for new register stats behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68614a783bc88324824f37392e1c7bb8