### PR TITLE
Add per-guild flex mode

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,12 +10,23 @@ from create_db import create_db
 from leaderboard_tasks import reset_lp_scheduler
 import leaderboard
 import register_stats
-from fonction_bdd import (insert_player, get_player_by_username, delete_player,
-                          username_autocomplete, get_player, get_all_players,
-                          get_guild, insert_guild, insert_player_guild,
-                          update_player_guild, update_player_global,
-                          get_leaderboard_by_guild, delete_leaderboard_member,
-                          count_players)
+from fonction_bdd import (
+    insert_player,
+    get_player_by_username,
+    delete_player,
+    username_autocomplete,
+    get_player,
+    get_all_players,
+    get_guild,
+    insert_guild,
+    insert_player_guild,
+    update_player_guild,
+    update_player_global,
+    get_leaderboard_by_guild,
+    delete_leaderboard_member,
+    count_players,
+    set_guild_flex_mode,
+)
 import requests
 import tracemalloc
 from pathlib import Path
@@ -107,7 +118,7 @@ async def async_fetch_json(url: str, headers: dict | None = None,
                         return None
                     resp.raise_for_status()
                     return await resp.json()
-        except aiohttp.ClientError as e:
+        except (aiohttp.ClientError, asyncio.TimeoutError) as e:
             if attempt == retries:
                 logging.error(f"Error fetching {url}: {e}")
                 return None
@@ -167,8 +178,8 @@ def get_summoner_id(puuid, region):
     data = fetch_json(url, headers=headers)
     return data.get('id') if data else None
 
-def get_summoner_rank_details(summoner_id: str, region: str):
-    """Return detailed solo/duo rank info for a summoner ID."""
+def get_summoner_rank_details(summoner_id: str, region: str, flex: bool = False):
+    """Return detailed rank info for a summoner ID."""
     region_code = normalize_region(region)
     url = (
         f"https://{region_code}.api.riotgames.com/lol/league/v4/entries/by-summoner/"
@@ -176,9 +187,10 @@ def get_summoner_rank_details(summoner_id: str, region: str):
     )
     headers = {"X-Riot-Token": RIOT_API_KEY}
     data = fetch_json(url, headers=headers)
+    queue = "RANKED_FLEX_SR" if flex else "RANKED_SOLO_5x5"
     if isinstance(data, list):
         for entry in data:
-            if entry.get("queueType") == "RANKED_SOLO_5x5":
+            if entry.get("queueType") == queue:
                 return {
                     "tier": entry.get("tier"),
                     "rank": entry.get("rank"),
@@ -189,8 +201,8 @@ def get_summoner_rank_details(summoner_id: str, region: str):
     return None
 
 
-def get_summoner_rank_details_by_puuid(puuid: str, region: str):
-    """Return detailed solo/duo rank info using the PUUID directly."""
+def get_summoner_rank_details_by_puuid(puuid: str, region: str, flex: bool = False):
+    """Return detailed rank info using the PUUID directly."""
     region_code = normalize_region(region)
     url = (
         f"https://{region_code}.api.riotgames.com/lol/league/v4/entries/by-puuid/"
@@ -198,9 +210,10 @@ def get_summoner_rank_details_by_puuid(puuid: str, region: str):
     )
     headers = {"X-Riot-Token": RIOT_API_KEY}
     data = fetch_json(url, headers=headers)
+    queue = "RANKED_FLEX_SR" if flex else "RANKED_SOLO_5x5"
     if isinstance(data, list):
         for entry in data:
-            if entry.get("queueType") == "RANKED_SOLO_5x5":
+            if entry.get("queueType") == queue:
                 return {
                     "tier": entry.get("tier"),
                     "rank": entry.get("rank"),
@@ -262,7 +275,7 @@ def init_champion_mapping() -> None:
             continue
 
 
-def get_match_details(match_id: str, puuid: str, region: str):
+def get_match_details(match_id: str, puuid: str, region: str, flex: bool = False):
     """
     Récupère les détails d'un match classé (.match/v5) pour un joueur donné (par son PUUID).
     Construit aussi l’URL de l’image du champion en utilisant la version Data Dragon la plus récente.
@@ -279,7 +292,8 @@ def get_match_details(match_id: str, puuid: str, region: str):
     if not match_data:
         return None
     game_mode = match_data.get("info", {}).get("queueId")
-    if game_mode == 420:
+    valid_queues = {420, 440} if flex else {420}
+    if game_mode in valid_queues:
         # Récupère la version Data Dragon à la volée
         ddragon_version = get_ddragon_latest_version()
 
@@ -309,6 +323,10 @@ def get_match_details(match_id: str, puuid: str, region: str):
                     f"{ddragon_version}/img/champion/{champ_slug}.png"
                 )
 
+                early_surrender = match_data.get("info", {}).get(
+                    "gameEndedInEarlySurrender", False
+                )
+
                 return (
                     result,
                     champion,
@@ -317,7 +335,8 @@ def get_match_details(match_id: str, puuid: str, region: str):
                     assists,
                     game_duration,
                     champion_image,
-                    damage
+                    damage,
+                    early_surrender,
                 )
 
     return None
@@ -331,7 +350,7 @@ async def check_username_changes():
         players = await async_get_all_players()
         for player in players:
             summoner_id, puuid, old_username, *rest = player
-            region = rest[-1]
+            region = rest[-2]
 
             region_code = normalize_region(region)
             routing = REGION_TO_ROUTING.get(region_code, "europe")
@@ -399,10 +418,10 @@ def calculate_lp_change(old_tier, old_rank, old_lp, new_tier, new_rank, new_lp):
         return 0
 
 
-async def is_in_game(puuid: str, region: str) -> int | None:
+async def is_in_game(puuid: str, region: str, flex: bool = False) -> int | None:
     """
-    Si le joueur est en ranked solo/duo (queue 420), renvoie son championId (int).
-    Sinon renvoie None.
+    Renvoie le championId du joueur s'il est en partie classée. Solo/duo par
+    défaut, ou Flex si ``flex`` est ``True``.
     """
     region_code = normalize_region(region)
     url = f"https://{region_code}.api.riotgames.com/lol/spectator/v5/active-games/by-summoner/{puuid}"
@@ -411,7 +430,8 @@ async def is_in_game(puuid: str, region: str) -> int | None:
     data = await async_fetch_json(url, headers=headers)
     if not data:
         return None
-    if data.get("gameQueueConfigId") != 420:
+    valid_queues = {420, 440} if flex else {420}
+    if data.get("gameQueueConfigId") not in valid_queues:
         return None
     for participant in data.get("participants", []):
         if participant.get("puuid") == puuid:
@@ -425,14 +445,14 @@ async def is_in_game(puuid: str, region: str) -> int | None:
 async def async_get_all_players():
     return await asyncio.to_thread(get_all_players)
 
-async def async_is_in_game(puuid, region):
-    return await is_in_game(puuid, region)
+async def async_is_in_game(puuid, region, flex: bool = False):
+    return await is_in_game(puuid, region, flex)
 
 async def async_get_last_match(puuid, nb_last_match, region):
     return await asyncio.to_thread(get_last_match, puuid, nb_last_match, region)
 
-async def async_get_match_details(match_id, puuid, region):
-    return await asyncio.to_thread(get_match_details, match_id, puuid, region)
+async def async_get_match_details(match_id, puuid, region, flex: bool = False):
+    return await asyncio.to_thread(get_match_details, match_id, puuid, region, flex)
 
 
 ###############################################################################
@@ -478,8 +498,12 @@ async def register(
     guild_id = interaction.guild.id
     channel_id = interaction.channel.id
 
-    if not get_guild(guild_id):
+    guild_row = get_guild(guild_id)
+    if not guild_row:
         insert_guild(guild_id, None)
+        flex = False
+    else:
+        flex = bool(guild_row[2])
 
     if get_player(puuid, guild_id):
         return await interaction.followup.send(
@@ -585,6 +609,8 @@ async def unregister(interaction: discord.Interaction, username: str):
 async def rank(interaction: discord.Interaction, username: str):
     """Show current rank for a registered player."""
     guild_id = interaction.guild.id
+    guild_row = get_guild(guild_id)
+    flex = bool(guild_row[2]) if guild_row else False
     username = username.upper()
     await interaction.response.defer()
 
@@ -595,7 +621,7 @@ async def rank(interaction: discord.Interaction, username: str):
 
     puuid = player[1]
     region = player[-1]
-    data = await asyncio.to_thread(get_summoner_rank_details_by_puuid, puuid, region)
+    data = await asyncio.to_thread(get_summoner_rank_details_by_puuid, puuid, region, flex)
     if not data:
         await interaction.followup.send("Unable to retrieve rank data.", ephemeral=True)
         return
@@ -654,6 +680,8 @@ async def rank(interaction: discord.Interaction, username: str):
 async def career(interaction: discord.Interaction, username: str):
     """Show the last 10 ranked Solo/Duo games for a registered player."""
     guild_id = interaction.guild.id
+    guild_row = get_guild(guild_id)
+    flex = bool(guild_row[2]) if guild_row else False
     username = username.upper()
     await interaction.response.defer()
     player = get_player_by_username(username, guild_id)
@@ -662,7 +690,7 @@ async def career(interaction: discord.Interaction, username: str):
         return
     puuid = player[1]
     region = player[-1]
-    data = await asyncio.to_thread(get_summoner_rank_details_by_puuid, puuid, region)
+    data = await asyncio.to_thread(get_summoner_rank_details_by_puuid, puuid, region, flex)
     if not data:
         await interaction.followup.send("Error retrieving player rank information!", ephemeral=True)
         return
@@ -673,9 +701,10 @@ async def career(interaction: discord.Interaction, username: str):
         return
     match_results = []
     for match_id in match_ids:
-        details = await async_get_match_details(match_id, puuid, region)
+        details = await async_get_match_details(match_id, puuid, region, flex)
         if details:
-            result, champion, kills, deaths, assists, game_duration, champion_image, damage = details
+            (result, champion, kills, deaths, assists, game_duration,
+             champion_image, damage, _early_surrender) = details
             match_results.append({
                 "result": result,
                 "champion": champion,
@@ -705,6 +734,27 @@ async def career(interaction: discord.Interaction, username: str):
             embed.add_field(name='\u200b', value='\u200b', inline=True)
     await interaction.followup.send(embed=embed)
 
+
+@tree.command(name="flex", description="Enable or disable flex mode for this server")
+@app_commands.describe(mode="on or off")
+async def flex(interaction: discord.Interaction, mode: str):
+    guild_id = interaction.guild.id
+    if mode.lower() not in {"on", "off"}:
+        await interaction.response.send_message("Use 'on' or 'off'.", ephemeral=True)
+        return
+    enabled = mode.lower() == "on"
+
+    guild_row = get_guild(guild_id)
+    if not guild_row:
+        insert_guild(guild_id, None, int(enabled))
+    else:
+        set_guild_flex_mode(guild_id, enabled)
+
+    await interaction.response.send_message(
+        f"Flex mode {'enabled' if enabled else 'disabled'}.",
+        ephemeral=True,
+    )
+
 ###############################################################################
 # Tâches de fond
 ###############################################################################
@@ -719,12 +769,13 @@ async def check_ingame():
         try:
             players = await async_get_all_players()
             for summoner_id, puuid, username, guild_id, channel_id, *rest in players:
-                region = rest[-1]
+                region = rest[-2]
+                flex = bool(rest[-1])
                 channel = client.get_channel(int(channel_id))
                 if not channel:
                     continue
 
-                champion_id = await is_in_game(puuid, region)
+                champion_id = await is_in_game(puuid, region, flex)
 
                 player_key = (puuid, guild_id)
 
@@ -825,9 +876,10 @@ async def check_for_game_completion():
                     old_lp,
                     *rest
                 ) = row
-                region = rest[-1]
+                region = rest[-2]
+                flex = bool(rest[-1])
 
-                if await async_is_in_game(puuid, region):
+                if await async_is_in_game(puuid, region, flex):
                     continue
 
                 last_matches = await async_get_last_match(puuid, 1, region)
@@ -837,10 +889,20 @@ async def check_for_game_completion():
                 if new_match_id == last_match_id:
                     continue
 
-                details = await async_get_match_details(new_match_id, puuid, region)
+                details = await async_get_match_details(new_match_id, puuid, region, flex)
                 if not details:
                     continue
-                result, champion, kills, deaths, assists, game_duration, champ_img, damage = details
+                (
+                    result,
+                    champion,
+                    kills,
+                    deaths,
+                    assists,
+                    game_duration,
+                    champ_img,
+                    damage,
+                    early_surrender,
+                ) = details
 
                 key = (puuid, new_match_id)
                 if key in recent_match_lp_changes:
@@ -880,13 +942,14 @@ async def check_for_game_completion():
                     )
                     recent_match_lp_changes[key] = (lp_change, now)
 
-                    update_player_global(
-                        puuid,
-                        tier=tier_str,
-                        rank=rank_str,
-                        lp=new_lp,
-                        lp_change=lp_change
-                    )
+                    if not flex:
+                        update_player_global(
+                            puuid,
+                            tier=tier_str,
+                            rank=rank_str,
+                            lp=new_lp,
+                            lp_change=lp_change
+                        )
 
                 update_player_guild(
                     puuid,
@@ -913,12 +976,13 @@ async def check_for_game_completion():
                         assists,
                         champ_img,
                         lp_change,
-                        damage
+                        damage,
+                        early_surrender,
                     )
 
                 guild_data = get_guild(guild_id)  # (guild_id, leaderboard_channel_id)
                 lb_channel_id = guild_data[1] if guild_data else None
-                if lb_channel_id:
+                if lb_channel_id and not flex:
                     await leaderboard.update_leaderboard_message(lb_channel_id, client, guild_id)
 
                 players_in_game.discard(player_key)
@@ -936,13 +1000,28 @@ async def check_for_game_completion():
         await asyncio.sleep(10)
 
 
-async def send_match_result_embed(channel, username, result, kills, deaths, assists,
-                                  champion_image, lp_change, damage):
-    game_result = "Victory" if result == ':green_circle:' else "Defeat"
+async def send_match_result_embed(
+    channel,
+    username,
+    result,
+    kills,
+    deaths,
+    assists,
+    champion_image,
+    lp_change,
+    damage,
+    early_surrender: bool = False,
+):
+    if early_surrender:
+        game_result = "Early Surrender"
+        color = discord.Color.orange()
+    else:
+        game_result = "Victory" if result == ':green_circle:' else "Defeat"
+        color = discord.Color.green() if result == ':green_circle:' else discord.Color.red()
     lp_text = "LP Win" if lp_change > 0 else "LP Lost"
     embed = discord.Embed(
         title=f"{game_result} for {username}",
-        color=discord.Color.green() if result == ':green_circle:' else discord.Color.red()
+        color=color,
     )
     embed.add_field(name="K/D/A", value=f"{kills}/{deaths}/{assists}", inline=True)
     embed.add_field(name="Damage", value=f"{damage}", inline=True)

--- a/create_db.py
+++ b/create_db.py
@@ -12,7 +12,8 @@ def create_db():
     c.execute("""
         CREATE TABLE IF NOT EXISTS guild (
             guild_id INTEGER PRIMARY KEY,
-            leaderboard_channel_id INTEGER
+            leaderboard_channel_id INTEGER,
+            flex_enabled INTEGER DEFAULT 0
         );
         """)
 

--- a/tests/test_async_fetch_json.py
+++ b/tests/test_async_fetch_json.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import asyncio
+import pytest
+
+@pytest.fixture(scope="module")
+def bot_module():
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    if 'bot' in sys.modules:
+        del sys.modules['bot']
+    with patch('discord.Client.run'):
+        module = importlib.import_module('bot')
+    module.discord_handler.emit = lambda *a, **k: None
+    return module
+
+
+def test_async_fetch_json_handles_timeout(bot_module):
+    mock_session = AsyncMock()
+    mock_session.__aenter__.return_value = mock_session
+
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def raise_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError
+        yield
+
+    mock_session.get = raise_timeout
+
+    with (
+        patch('aiohttp.ClientSession', return_value=mock_session),
+        patch('asyncio.sleep', new=AsyncMock()),
+        patch.object(bot_module.logging, 'error') as log_error,
+    ):
+        result = asyncio.run(bot_module.async_fetch_json('http://example.com'))
+
+    assert result is None
+    log_error.assert_called_once()

--- a/tests/test_check_game_completion.py
+++ b/tests/test_check_game_completion.py
@@ -35,3 +35,35 @@ def test_check_for_game_completion_handles_missing_row(bot_module):
 
     assert ('puuid1', 1) not in bot_module.players_in_game
     assert ('puuid1', 1) not in bot_module.players_in_game_messages
+
+
+def test_check_for_game_completion_skips_flex_updates(bot_module):
+    row = (
+        'sid', 'puuid2', 'User', 1, 10, 'm1',
+        'IV', 'GOLD', 50, 0, 0, 'euw1', 1
+    )
+    bot_module.players_in_game = {('puuid2', 1)}
+    bot_module.players_in_game_messages = {('puuid2', 1): MagicMock()}
+    bot_module.recent_match_lp_changes = {}
+
+    with (
+        patch.object(bot_module, 'async_get_all_players', AsyncMock(return_value=[row])),
+        patch.object(bot_module, 'async_is_in_game', AsyncMock(return_value=False)),
+        patch.object(bot_module, 'async_get_last_match', AsyncMock(return_value=['m2'])),
+        patch.object(bot_module, 'async_get_match_details', AsyncMock(return_value=(
+            ':green_circle:', 'Champ', 1, 2, 3, 1800, 'img', 1000, False
+        ))),
+        patch.object(bot_module, 'get_summoner_rank_details_by_puuid', AsyncMock(return_value={
+            'tier': 'GOLD', 'rank': 'IV', 'lp': 50
+        })),
+        patch.object(bot_module, 'send_match_result_embed', AsyncMock()),
+        patch.object(bot_module.leaderboard, 'update_leaderboard_message') as upd_lb,
+        patch.object(bot_module, 'update_player_global') as upd_global,
+        patch('asyncio.sleep', AsyncMock(side_effect=asyncio.CancelledError)),
+        patch.object(bot_module.register_stats, 'update_register_message', new=AsyncMock()),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(bot_module.check_for_game_completion())
+
+    upd_global.assert_not_called()
+    upd_lb.assert_not_called()

--- a/tests/test_flex_command.py
+++ b/tests/test_flex_command.py
@@ -1,0 +1,50 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch, MagicMock
+import asyncio
+import pytest
+
+@pytest.fixture(scope="module")
+def bot_module():
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    if 'bot' in sys.modules:
+        del sys.modules['bot']
+    with patch('discord.Client.run'):
+        module = importlib.import_module('bot')
+    module.discord_handler.emit = lambda *a, **k: None
+    return module
+
+
+def test_flex_command_enable(bot_module):
+    interaction = MagicMock()
+    interaction.guild.id = 1
+    interaction.response.send_message = AsyncMock()
+
+    with (
+        patch.object(bot_module, 'get_guild', return_value=None),
+        patch.object(bot_module, 'insert_guild') as ins_guild,
+        patch.object(bot_module, 'set_guild_flex_mode') as set_flex,
+    ):
+        asyncio.run(bot_module.flex.callback(interaction, 'on'))
+
+    ins_guild.assert_called_once_with(1, None, 1)
+    set_flex.assert_not_called()
+    interaction.response.send_message.assert_awaited_once()
+
+
+def test_flex_command_disable(bot_module):
+    interaction = MagicMock()
+    interaction.guild.id = 2
+    interaction.response.send_message = AsyncMock()
+
+    with (
+        patch.object(bot_module, 'get_guild', return_value=(2, None, 1)),
+        patch.object(bot_module, 'set_guild_flex_mode') as set_flex,
+    ):
+        asyncio.run(bot_module.flex.callback(interaction, 'off'))
+
+    set_flex.assert_called_once_with(2, False)
+    interaction.response.send_message.assert_awaited_once()
+

--- a/tests/test_send_match_result_embed.py
+++ b/tests/test_send_match_result_embed.py
@@ -1,0 +1,41 @@
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import asyncio
+import discord
+import pytest
+
+@pytest.fixture(scope="module")
+def bot_module():
+    root = Path(__file__).resolve().parents[1]
+    sys.path.insert(0, str(root))
+    if 'bot' in sys.modules:
+        del sys.modules['bot']
+    with patch('discord.Client.run'):
+        module = importlib.import_module('bot')
+    module.discord_handler.emit = lambda *a, **k: None
+    return module
+
+
+def test_send_match_result_embed_early_surrender(bot_module):
+    channel = AsyncMock()
+    asyncio.run(
+        bot_module.send_match_result_embed(
+            channel,
+            'Player',
+            ':red_circle:',
+            1,
+            2,
+            3,
+            'http://image',
+            -10,
+            1000,
+            True,
+        )
+    )
+
+    channel.send.assert_awaited_once()
+    embed = channel.send.call_args.kwargs['embed']
+    assert embed.title == 'Early Surrender for Player'
+    assert embed.color.value == discord.Color.orange().value


### PR DESCRIPTION
## Summary
- extend DB guild table with `flex_enabled`
- expose DB helpers `set_guild_flex_mode` and update `insert_guild`
- implement `/flex on|off` command
- support flex queue in match checks when enabled
- keep leaderboard updates based on solo queue only
- test flex mode and match completion logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863934e21ac83248901230762cdbab6