### PR TITLE
Fix Riot API updates

### DIFF
--- a/create_db.py
+++ b/create_db.py
@@ -12,7 +12,8 @@ def create_db():
     c.execute("""
         CREATE TABLE IF NOT EXISTS guild (
             guild_id INTEGER PRIMARY KEY,
-            leaderboard_channel_id INTEGER
+            leaderboard_channel_id INTEGER,
+            flex_enabled INTEGER DEFAULT 0
         );
         """)
 
@@ -20,7 +21,6 @@ def create_db():
         CREATE TABLE IF NOT EXISTS player (
             username TEXT NOT NULL,
             puuid TEXT PRIMARY KEY,
-            summoner_id TEXT NOT NULL,
             rank TEXT,
             tier TEXT,
             lp INTEGER,

--- a/leaderboard.py
+++ b/leaderboard.py
@@ -38,7 +38,7 @@ async def leaderboard_cmd(
     guild_id = guild.id
 
     # 2) Enregistrement du salon comme channel de leaderboard
-    insert_guild(guild_id, new_channel.id)
+    insert_guild(guild_id, new_channel.id, 0)
 
     lb_id = get_leaderboard_by_guild(guild_id)
     if lb_id is None:


### PR DESCRIPTION
## Summary
- adjust async_fetch_json to catch TimeoutError
- drop summoner id API calls and reuse puuid instead
- support flex mode and spectate reaction
- handle early surrenders in result embeds
- store flex setting in guild table
- remove `summoner_id` column and references

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876d1eacd4483248725108423a75b3e