### PR TITLE
Add multi-region registration support

### DIFF
--- a/Backend/create_db.py
+++ b/Backend/create_db.py
@@ -24,6 +24,7 @@ def create_db():
             rank TEXT,
             tier TEXT,
             lp INTEGER,
+            region TEXT,
             flex_rank TEXT,
             flex_tier TEXT,
             flex_lp INTEGER,

--- a/Backend/fonction_bdd.py
+++ b/Backend/fonction_bdd.py
@@ -15,6 +15,7 @@ def insert_player(puuid: str,
                   tier: str,
                   rank: str,
                   lp: int,
+                  region: str,
                   flex_tier: str = None,
                   flex_rank: str = None,
                   flex_lp: int = None):
@@ -27,10 +28,10 @@ def insert_player(puuid: str,
     c.execute(
         """
         INSERT OR IGNORE INTO player
-          (puuid, username, tier, rank, lp, flex_tier, flex_rank, flex_lp, lp_24h, lp_7d, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+          (puuid, username, tier, rank, lp, region, flex_tier, flex_rank, flex_lp, lp_24h, lp_7d, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
         """,
-        (puuid, username, tier, rank, lp, flex_tier, flex_rank, flex_lp),
+        (puuid, username, tier, rank, lp, region, flex_tier, flex_rank, flex_lp),
     )
     c.execute(
         """
@@ -39,13 +40,14 @@ def insert_player(puuid: str,
             tier = ?,
             rank = ?,
             lp = ?,
+            region = ?,
             flex_tier = ?,
             flex_rank = ?,
             flex_lp = ?,
             updated_at = CURRENT_TIMESTAMP
         WHERE puuid = ?
         """,
-        (username, tier, rank, lp, flex_tier, flex_rank, flex_lp, puuid),
+        (username, tier, rank, lp, region, flex_tier, flex_rank, flex_lp, puuid),
     )
     conn.commit()
     conn.close()
@@ -56,6 +58,7 @@ def update_player_global(puuid: str,
                          lp: int = None,
                          lp_change: int = None,
                          username: str = None,
+                         region: str = None,
                          flex_tier: str = None,
                          flex_rank: str = None,
                          flex_lp: int = None):
@@ -81,6 +84,9 @@ def update_player_global(puuid: str,
     if lp is not None:
         updates.append("lp = ?")
         params.append(lp)
+    if region is not None:
+        updates.append("region = ?")
+        params.append(region)
     if flex_tier is not None:
         updates.append("flex_tier = ?")
         params.append(flex_tier)
@@ -181,7 +187,7 @@ def get_player(puuid: str, guild_id: int):
         """
         SELECT
             p.puuid, p.username,
-            pg.guild_id, pg.channel_id, pg.last_match_id,
+            pg.guild_id, pg.channel_id, p.region, pg.last_match_id,
             p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d,
             p.flex_tier, p.flex_rank, p.flex_lp
         FROM player p
@@ -202,7 +208,7 @@ def get_all_players():
         """
         SELECT
             p.puuid, p.username,
-            pg.guild_id, pg.channel_id, pg.last_match_id,
+            pg.guild_id, pg.channel_id, p.region, pg.last_match_id,
             p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d,
             p.flex_tier, p.flex_rank, p.flex_lp
         FROM player p
@@ -222,7 +228,7 @@ def get_player_by_username(username: str, guild_id: int = None):
             """
             SELECT
                 p.puuid, p.username,
-                pg.guild_id, pg.channel_id, pg.last_match_id,
+                pg.guild_id, pg.channel_id, p.region, pg.last_match_id,
                 p.tier, p.rank, p.lp, p.lp_24h, p.lp_7d,
                 p.flex_tier, p.flex_rank, p.flex_lp
             FROM player p
@@ -233,7 +239,7 @@ def get_player_by_username(username: str, guild_id: int = None):
         )
         result = c.fetchone()
     else:
-        c.execute("SELECT puuid, username FROM player WHERE username = ?", (username,))
+        c.execute("SELECT puuid, username, region FROM player WHERE username = ?", (username,))
         result = c.fetchone()
     conn.close()
     return result

--- a/Backend/tests/test_check_game_completion.py
+++ b/Backend/tests/test_check_game_completion.py
@@ -42,7 +42,7 @@ def test_check_for_game_completion_updates_flex_rank(bot_module):
     bot_module.recent_match_lp_changes = {}
 
     row = (
-        'p1', 'USER#TAG', 1, 123, 'm0',
+        'p1', 'USER#TAG', 1, 123, 'euw1', 'm0',
         'IV', 'GOLD', 50, 0, 0,
         'III', 'SILVER', 20
     )
@@ -77,7 +77,7 @@ def test_check_for_game_completion_updates_flex_rank(bot_module):
         with pytest.raises(asyncio.CancelledError):
             asyncio.run(bot_module.check_for_game_completion())
 
-    async_is_in_game.assert_awaited_once_with('p1', True)
+    async_is_in_game.assert_awaited_once_with('p1', 'euw1', True)
     update_player_global.assert_called_once_with(
         'p1',
         flex_tier='II',

--- a/Backend/tests/test_flex_command.py
+++ b/Backend/tests/test_flex_command.py
@@ -27,7 +27,7 @@ def test_flex_command_enable(bot_module):
         patch.object(bot_module, 'insert_guild') as ins_guild,
         patch.object(bot_module, 'set_guild_flex_mode') as set_flex,
     ):
-        asyncio.run(bot_module.flex.callback(interaction, 'on'))
+        asyncio.run(bot_module.flex.callback(interaction, 'enable'))
 
     ins_guild.assert_called_once_with(1, None, 1)
     set_flex.assert_not_called()
@@ -43,7 +43,7 @@ def test_flex_command_disable(bot_module):
         patch.object(bot_module, 'get_guild', return_value=(2, None, 1)),
         patch.object(bot_module, 'set_guild_flex_mode') as set_flex,
     ):
-        asyncio.run(bot_module.flex.callback(interaction, 'off'))
+        asyncio.run(bot_module.flex.callback(interaction, 'disable'))
 
     set_flex.assert_called_once_with(2, False)
     interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- allow registering players from multiple regions and map short codes to Riot platform/cluster
- store player region in the database and propagate it across match and rank queries
- adjust tests for updated region-aware logic

## Testing
- `cd Backend && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a49f04baac83249e6d3c02dc4d4420