### PR TITLE
Allow per-guild configurable leaderboard reset timezone

### DIFF
--- a/Backend/create_db.py
+++ b/Backend/create_db.py
@@ -13,7 +13,10 @@ def create_db():
         CREATE TABLE IF NOT EXISTS guild (
             guild_id INTEGER PRIMARY KEY,
             leaderboard_channel_id INTEGER,
-            flex_enabled INTEGER DEFAULT 0
+            flex_enabled INTEGER DEFAULT 0,
+            reset_timezone TEXT DEFAULT 'Europe/Paris',
+            daily_recap_enabled INTEGER DEFAULT 0,
+            weekly_recap_enabled INTEGER DEFAULT 0
         );
         """)
 

--- a/Backend/leaderboard_tasks.py
+++ b/Backend/leaderboard_tasks.py
@@ -1,6 +1,17 @@
 import asyncio
-from datetime import datetime, date, time, timedelta
-from fonction_bdd import get_all_players, reset_all_lp_24h, reset_all_lp_7d
+from datetime import datetime, time, timedelta
+from zoneinfo import ZoneInfo
+from fonction_bdd import (
+    get_all_players,
+    get_all_guild_timezones,
+    get_reset_timezone,
+    reset_lp_24h_for_guild,
+    reset_lp_7d_for_guild,
+    is_recap_enabled,
+    get_guild,
+    get_leaderboard_by_guild,
+    get_leaderboard_data,
+)
 from leaderboard import update_leaderboard_message
 
 leaderboard_update_event = asyncio.Event()
@@ -19,38 +30,76 @@ async def notify_leaderboard_update(bot):
         await asyncio.sleep(1)
 
 async def reset_lp_scheduler(bot):
-    """
-    Lance deux coroutines :
-     - daily at 00:00 → reset lp_24h
-     - every Monday at 00:00 → reset lp_7d
-    Et déclenche leaderboard_update_event à chaque reset.
-    """
+    """Schedule LP resets per guild according to each timezone."""
+
     async def wait_until(target: datetime):
-        now = datetime.now()
+        now = datetime.now(target.tzinfo)
         delta = (target - now).total_seconds()
         if delta > 0:
             await asyncio.sleep(delta)
 
-    async def daily_reset():
-        while True:
-            today = date.today()
-            next_midnight = datetime.combine(today + timedelta(days=1), time.min)
-            await wait_until(next_midnight)
+    async def send_recap(guild_id: int, period: str):
+        lb_id = get_leaderboard_by_guild(guild_id)
+        if lb_id is None:
+            return
+        rows = get_leaderboard_data(lb_id, guild_id)
+        if not rows:
+            return
+        guild_row = get_guild(guild_id)
+        if not guild_row:
+            return
+        channel_id = guild_row[1]
+        if channel_id is None:
+            return
+        channel = bot.get_channel(channel_id)
+        if channel is None:
+            return
+        index = 4 if period == "daily" else 5
+        sorted_rows = sorted(rows, key=lambda r: r[index], reverse=True)
+        title = "Daily" if period == "daily" else "Weekly"
+        lines = [
+            f"{i+1}. {row[0]}: {row[index]} LP" for i, row in enumerate(sorted_rows)
+        ]
+        if lines:
+            await channel.send("**" + title + " recap**\n" + "\n".join(lines))
 
-            reset_all_lp_24h()
+    async def daily_reset(guild_id: int):
+        while True:
+            tz = ZoneInfo(get_reset_timezone(guild_id))
+            now = datetime.now(tz)
+            next_midnight = datetime.combine(
+                now.date() + timedelta(days=1), time.min, tzinfo=tz
+            )
+            await wait_until(next_midnight)
+            if is_recap_enabled(guild_id, "daily"):
+                await send_recap(guild_id, "daily")
+            reset_lp_24h_for_guild(guild_id)
             leaderboard_update_event.set()
 
-    async def weekly_reset():
+    async def weekly_reset(guild_id: int):
         while True:
-            today = date.today()
-            days_ahead = (0 - today.weekday() + 7) % 7
+            tz = ZoneInfo(get_reset_timezone(guild_id))
+            now = datetime.now(tz)
+            days_ahead = (0 - now.weekday() + 7) % 7
             if days_ahead == 0:
                 days_ahead = 7
-            next_monday = datetime.combine(today + timedelta(days=days_ahead), time.min)
+            next_monday_date = (now + timedelta(days=days_ahead)).date()
+            next_monday = datetime.combine(next_monday_date, time.min, tzinfo=tz)
             await wait_until(next_monday)
-
-            reset_all_lp_7d()
+            if is_recap_enabled(guild_id, "weekly"):
+                await send_recap(guild_id, "weekly")
+            reset_lp_7d_for_guild(guild_id)
             leaderboard_update_event.set()
 
-    bot.loop.create_task(daily_reset())
-    bot.loop.create_task(weekly_reset())
+    scheduled: set[int] = set()
+
+    async def ensure_tasks():
+        while True:
+            for guild_id, _ in get_all_guild_timezones():
+                if guild_id not in scheduled:
+                    bot.loop.create_task(daily_reset(guild_id))
+                    bot.loop.create_task(weekly_reset(guild_id))
+                    scheduled.add(guild_id)
+            await asyncio.sleep(3600)
+
+    bot.loop.create_task(ensure_tasks())

--- a/Backend/tests/test_help_command.py
+++ b/Backend/tests/test_help_command.py
@@ -1,0 +1,15 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from test_flex_command import bot_module
+
+
+def test_help_command(bot_module):
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    asyncio.run(bot_module.help_cmd.callback(interaction))
+
+    interaction.response.send_message.assert_awaited_once_with(
+        "Need help? Join our support server: https://discord.gg/vZHPkBHmkC",
+        ephemeral=True,
+    )

--- a/Backend/tests/test_howtosetup_command.py
+++ b/Backend/tests/test_howtosetup_command.py
@@ -1,0 +1,20 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+from test_flex_command import bot_module
+
+
+def test_howtosetup_command(bot_module):
+    interaction = MagicMock()
+    interaction.response.send_message = AsyncMock()
+
+    asyncio.run(bot_module.howtosetup_cmd.callback(interaction))
+
+    interaction.response.send_message.assert_awaited_once_with(
+        (
+            "To set up the bot: /leaderboard creates a leaderboard channel, "
+            "/register adds players, /settime chooses your reset timezone, "
+            "/recap daily|weekly enable enables recap messages. For more help join "
+            "https://discord.gg/vZHPkBHmkC"
+        ),
+        ephemeral=True,
+    )

--- a/Backend/tests/test_recap_settings.py
+++ b/Backend/tests/test_recap_settings.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+import create_db
+import fonction_bdd
+
+TEST_DB = root / "test_recap.db"
+create_db.DB_PATH = str(TEST_DB)
+fonction_bdd.DB_PATH = str(TEST_DB)
+
+def setup_module(module):
+    if TEST_DB.exists():
+        TEST_DB.unlink()
+    create_db.create_db()
+
+def teardown_module(module):
+    if TEST_DB.exists():
+        TEST_DB.unlink()
+
+def test_default_recap_disabled():
+    assert not fonction_bdd.is_recap_enabled(123, "daily")
+    assert not fonction_bdd.is_recap_enabled(123, "weekly")
+
+def test_enable_disable_recap():
+    fonction_bdd.set_recap_mode(123, "daily", True)
+    assert fonction_bdd.is_recap_enabled(123, "daily")
+    fonction_bdd.set_recap_mode(123, "daily", False)
+    assert not fonction_bdd.is_recap_enabled(123, "daily")

--- a/Backend/tests/test_reset_timezone.py
+++ b/Backend/tests/test_reset_timezone.py
@@ -1,0 +1,33 @@
+import os
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(root))
+
+import create_db
+import fonction_bdd
+
+TEST_DB = root / "test_timezone.db"
+create_db.DB_PATH = str(TEST_DB)
+fonction_bdd.DB_PATH = str(TEST_DB)
+
+
+def setup_module(module):
+    if TEST_DB.exists():
+        TEST_DB.unlink()
+    create_db.create_db()
+
+
+def teardown_module(module):
+    if TEST_DB.exists():
+        TEST_DB.unlink()
+
+
+def test_default_timezone():
+    assert fonction_bdd.get_reset_timezone(123) == "Europe/Paris"
+
+
+def test_set_timezone():
+    fonction_bdd.set_reset_timezone(123, "UTC")
+    assert fonction_bdd.get_reset_timezone(123) == "UTC"


### PR DESCRIPTION
## Summary
- allow guilds to enable daily or weekly recap messages
- schedule recaps to post at each guild's reset time
- add `/recap` command to toggle recap frequency
- add `/help` command linking to support server
- add `/howtosetup` command with setup instructions
- document leaderboard setup in `/howtosetup`
- keep alerts enabled even if the bot lacks channel permissions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9f1caab883248d2471d9216d86cf